### PR TITLE
Updated Swift Package Manager configuration and codebase so it can be used with modern projects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -2,5 +2,8 @@
 import PackageDescription
 
 let package = Package(
-    name: "SwiftMsgPack"
+    name: "SwiftMsgPack",
+    targets: [
+        .target(name: "SwiftMsgPack")
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,10 @@ let package = Package(
         .library(name: "SwiftMsgPack", targets: ["SwiftMsgPack"])
     ],
     targets: [
-        .target(name: "SwiftMsgPack")
+        .target(name: "SwiftMsgPack"),
+        .testTarget(
+            name: "SwiftMsgPackTests",
+            dependencies: ["SwiftMsgPack"]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftMsgPack",
+    products: [
+        .library(name: "SwiftMsgPack", targets: ["SwiftMsgPack"])
+    ],
     targets: [
         .target(name: "SwiftMsgPack")
     ]

--- a/README.md
+++ b/README.md
@@ -13,18 +13,22 @@ Made with ♥ in pure Swift, no dependencies, lightweight & fully portable
 [MessagePack](http://msgpack.org/) is an efficient binary serialization format, which lets you exchange data among multiple languages like JSON, except that it's faster and smaller. Small integers are encoded into a single byte while typical short strings require only one extra byte in addition to the strings themselves.
 You can read more about [specs directly from the main web](https://github.com/msgpack/msgpack/blob/master/spec.md) site.
 
-## You also may like
+## OTHER LIBRARIES YOU MAY LIKE
 
-Do you like `SwiftMsgPack`? I'm also working on several other opensource libraries.
+I'm also working on several other projects you may like.
+Take a look below:
 
-Take a look here:
+<p align="center" >
 
-* **[SwiftDate](https://github.com/malcommac/SwiftDate)** - Date & Timezone management in Swift
-* **[Hydra](https://github.com/malcommac/Hydra)** - Promise, Async/Await on sterioids!
-* **[SwiftLocation](https://github.com/malcommac/SwiftLocation)** - CoreLocation and Beacon Monitoring on steroid!
-* **[SwiftRichString](https://github.com/malcommac/SwiftRichString)** - Elegant and painless attributed string in Swift
-* **[SwiftScanner](https://github.com/malcommac/SwiftScanner)** - String scanner in pure Swift with full unicode support
-* **[SwiftSimplify](https://github.com/malcommac/SwiftSimplify)** - Tiny high-performance Swift Polyline Simplification Library
+| Library         | Description                                      |
+|-----------------|--------------------------------------------------|
+| [**SwiftDate**](https://github.com/malcommac/SwiftDate)       | The best way to manage date/timezones in Swift   |
+| [**Hydra**](https://github.com/malcommac/Hydra)           | Write better async code: async/await & promises  |
+| [**Flow**](https://github.com/malcommac/Flow) | A new declarative approach to table managment. Forget datasource & delegates. |
+| [**SwiftRichString**](https://github.com/malcommac/SwiftRichString) | Elegant & Painless NSAttributedString in Swift   |
+| [**SwiftLocation**](https://github.com/malcommac/SwiftLocation)   | Efficient location manager                       |
+| [**SwiftMsgPack**](https://github.com/malcommac/SwiftMsgPack)    | Fast/efficient msgPack encoder/decoder           |
+</p>
 
 ## Index
 * **[Current Release](#release)**

--- a/Sources/SwiftMsgPack/Decoder.swift
+++ b/Sources/SwiftMsgPack/Decoder.swift
@@ -127,7 +127,7 @@ private struct StreamReader {
 		guard index + length <= data.count else {
 			throw MsgPackError.unexpectedData
 		}
-		let range = Range(index..<(index + length))
+		let range = index ..< (index + length)
 		index += length
 		return data.subdata(in: range)
 	}
@@ -144,7 +144,7 @@ public extension Data {
 	///
 	/// - Returns: decoded data
 	/// - Throws: an error if decoding task cannot be finished correctly due to an error
-	public func unpack() throws -> Any? {
+    func unpack() throws -> Any? {
 		// Create a reader which has a point to the current position in data instance
 		// and several help functions to read data
 		var reader = StreamReader(self)

--- a/Sources/SwiftMsgPack/Encoder.swift
+++ b/Sources/SwiftMsgPack/Encoder.swift
@@ -46,7 +46,7 @@ public extension Data {
 	/// - Returns: `self` `(maybe used to chain multiple pack`)
 	/// - Throws: throw an exception if packing fails for some reason
 	@discardableResult
-	public mutating func pack(_ objects: Any?...) throws -> Data {
+    mutating func pack(_ objects: Any?...) throws -> Data {
 		try objects.forEach { try self.pack($0) }
 		return self
 	}
@@ -62,7 +62,7 @@ public extension Data {
 	/// - Returns: `self` `(maybe used to chain multiple pack`)
 	/// - Throws: throw an exception if packing fails for some reason
 	@discardableResult
-	public mutating func pack(_ obj: Any?) throws -> Data {
+	mutating func pack(_ obj: Any?) throws -> Data {
 		
 		guard let obj = obj else {
 			// If the object is nil we want to write the nil
@@ -200,7 +200,7 @@ public extension Data {
 	/// - Parameter bool: boolean value to pack
 	/// - Returns: the instance of `self` modified with the packed data
 	@discardableResult
-	public mutating func pack(boolean bool: Bool) throws -> Data {
+	mutating func pack(boolean bool: Bool) throws -> Data {
 		try self.writeDataTypeHeader(.boolean(bool))
 		return self
 	}

--- a/Tests/SwiftMsgPackTests/SwiftMsgPackTests_BoolNil.swift
+++ b/Tests/SwiftMsgPackTests/SwiftMsgPackTests_BoolNil.swift
@@ -88,7 +88,7 @@ class SwiftMsgPackTests_BoolNil: XCTestCase {
 			
 		} catch let err {
 			// Something went wrong while packing data
-			XCTFail("[\(testName)] Failed to pack nil: \(err) (src='\(value)')")
+            XCTFail("[\(testName)] Failed to pack nil: \(err) (src='\(String(describing: value))')")
 			return
 		}
 	}

--- a/Tests/SwiftMsgPackTests/SwiftMsgPackTests_Data.swift
+++ b/Tests/SwiftMsgPackTests/SwiftMsgPackTests_Data.swift
@@ -95,7 +95,7 @@ class SwiftMsgPackTests_Data: XCTestCase {
 		// Append real data
 		bytes.append(contentsOf: data_sequence)
 		// Get generated data
-		let data = Data(bytes: data_sequence)
+		let data = Data(data_sequence)
 		return (data,bytes)
 	}
 	

--- a/Tests/SwiftMsgPackTests/SwiftMsgPackTests_String.swift
+++ b/Tests/SwiftMsgPackTests/SwiftMsgPackTests_String.swift
@@ -180,7 +180,7 @@ class SwiftMsgPackTests_String: XCTestCase {
 				XCTFail("[\(testName)] Failed to cast unpacked data to a valid String instance")
 				return
 			}
-			guard str_value.characters.count == value.characters.count else {
+			guard str_value.count == value.count else {
 				XCTFail("[\(testName)] Unpacked string has a different number of characters than source")
 				return
 			}


### PR DESCRIPTION
Unfortunately, the existing configuration isn't compatible with the new SPM. Because of this I have updated the SPM configuration and fixed some errors and warnings that have arisen due to the usage of this project with a modern Swift 5.1 codebase. Also, I've created an XCode test target and fixed outdated Swift syntax in tests.