### PR TITLE
Pack booleans before integers, to avoid accidental mis-casting

### DIFF
--- a/Sources/SwiftMsgPack/Encoder.swift
+++ b/Sources/SwiftMsgPack/Encoder.swift
@@ -76,6 +76,11 @@ public extension Data {
 			try self.pack(string: value_str)
 		}
 		
+		// BOOLEAN VALUES
+		else if let value_bool = obj as? Bool {
+			try self.pack(boolean: value_bool)
+		}
+		
 		// UNSIGNED INT
 		else if let value_u8 = obj as? UInt8 { // 8 BIT
 			//try self.pack(signedInt: Int(value_u8))
@@ -133,11 +138,6 @@ public extension Data {
 		else if let value_char = obj as? Character {
 			try self.pack(string: String(value_char))
 		}
-		// BOOLEAN VALUES
-		else if let value_bool = obj as? Bool {
-			try self.pack(boolean: value_bool)
-		}
-		
 		// ARRAY
 		else if let value_array = obj as? [Any?] {
 			try self.pack(array: value_array)


### PR DESCRIPTION
I noticed that booleans end up getting packed as a `0` or `1` instead of a boolean value since the boolean value gets cast to an integer. This fixes that behaviour by packing booleans before integers.